### PR TITLE
:twisted_rightwards_arrows: fix PHPStan error

### DIFF
--- a/src/Repository/FigureRepository.php
+++ b/src/Repository/FigureRepository.php
@@ -52,6 +52,9 @@ class FigureRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * @return Paginator<Figure>
+     */
     public function paginateFigures(int $page, int $limit) : Paginator
     {
         return new Paginator($this

--- a/src/Repository/MessageRepository.php
+++ b/src/Repository/MessageRepository.php
@@ -44,6 +44,9 @@ class MessageRepository extends ServiceEntityRepository
     //    }
 
 
+    /**
+     * @return Paginator<Message>
+     */
     public function findByFigureId(int $page, int $limit, int $figureId):
     Paginator
     {


### PR DESCRIPTION
fix paginateFigures() paginateMessages() return type with generic class  
Doctrine\ORM\Tools\Pagination\Paginator does not specify its types: T